### PR TITLE
Fix breadcrumb for indices sites

### DIFF
--- a/_includes/breadcrumbs.html
+++ b/_includes/breadcrumbs.html
@@ -12,8 +12,9 @@
 			<nav class="cell" aria-label="{% t global.you_are_here %}:" role="navigation">
 				<ul id="breadcrumbs" class="breadcrumbs">
 					{% assign crumbs = page.url | remove:'/index.html' | split: '/' %}
-					{% assign frontpage = "/" | relative_url %}
-					{% if frontpage == page.url | relative_url %}
+					{% assign frontpage = "/" | relative_url | remove:'index.html' %}
+					{% assign nodeurl = page.url | relative_url | remove:'index.html' %}
+					{% if frontpage == nodeurl %}
 					<li>
 						<span class="show-for-sr">{% t global.current %}: </span> {% t global.home %}
 					</li>


### PR DESCRIPTION
Apparently you cannot apply filter in liquid control sequences. So I had
to assign page.url to a variable to apply `relative_url` and
`remove: index.html`. This fixes the rendering of a link instead of text